### PR TITLE
Add proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-Simplest possible [Eclair](https://github.com/ACINQ/eclair) plugin. The latest supported version of Eclair is 0.8.0
+# Eclair Alarm Bot Plugin
+
+Simplest possible [Eclair](https://github.com/ACINQ/eclair) plugin. It sends Eclair notifications to a Telegram bot. The latest supported version of Eclair is 0.8.0.
 
 It can be upgraded with new events or even important node statistics.
 
@@ -18,7 +20,7 @@ mvn install -DskipTests=true
 
 Then build the plugin
 ```bash
-git clone https://github.com/engenegr/eclair-alarmbot-plugin.git
+git clone https://github.com/evd0kim/eclair-alarmbot-plugin.git
 
 cd eclair-alarmbot-plugin/
 
@@ -44,16 +46,17 @@ config {
     botApiKey = "PUT_YOUR_BOT_KEY_HERE"
     chatId = "PUT_ID_OF_YOUR_PERSONAL_CHAT"
     hedgeServiceUri = "OPTIONAL_URL_TO_YOUR_HEDGE_SERVICE"
+    useProxy = "IF_TRUE_USE_ECLAIR_PROXY"
 }
 ```
 
-## How to get `chatId`?
+## How to get Telegram `chatId`?
 
-1. Start new bot
+1. Start a new bot
 2. Use `curl` for getting bot updates from Telegram
 ```
 curl https://api.telegram.org/bot<PUT_YOUR_BOT_KEY_HERE>/getUpdates
 ```
 3. You should get response from Telegram server where you can find your 
    `chatId`. If it didn't happen, try to write something in the Bot chat
-   and repeat 2.
+   and repeat step 2.

--- a/src/main/scala/fr/acinq/alarmbot/AlarmBotConfig.scala
+++ b/src/main/scala/fr/acinq/alarmbot/AlarmBotConfig.scala
@@ -15,4 +15,6 @@ class AlarmBotConfig(datadir: File) {
   val chatId: String = config.as[String]("config.chatId")
 
   val hedgeService: Option[String] = config.as[Option[String]]("config.hedgeServiceUri")
+
+  val useProxy: Boolean = config.as[Option[Boolean]]("config.useProxy").getOrElse(true)
 }

--- a/src/main/scala/fr/acinq/alarmbot/ExternalHedgeClient.scala
+++ b/src/main/scala/fr/acinq/alarmbot/ExternalHedgeClient.scala
@@ -13,7 +13,8 @@ import scala.util.{Failure, Success, Try}
 class ExternalHedgeClient(kit: Kit, setup: Setup, pluginConfig: AlarmBotConfig) extends DiagnosticActorLogging {
   val kolliderClient = new KolliderClient(pluginConfig)
 
-  import setup.{ec, sttpBackend}
+  import setup.ec
+  implicit val sttpBackend = SttpUtil.createSttpBackend(kit.nodeParams.socksProxy_opt, pluginConfig.useProxy, log)
 
   implicit val serialization: Serialization = Serialization
 


### PR DESCRIPTION
Allows the plugin to connect to Telegram using proxy if it's configured in eclair.conf.